### PR TITLE
Adding @Subject annotation to TransactionRepository spec

### DIFF
--- a/src/test/groovy/com/kinandcarta/transactionsapi/controller/TransactionsApiExceptionHandlerSpec.groovy
+++ b/src/test/groovy/com/kinandcarta/transactionsapi/controller/TransactionsApiExceptionHandlerSpec.groovy
@@ -13,7 +13,7 @@ class TransactionsApiExceptionHandlerSpec extends Specification {
         final def target = new TransactionsApiExceptionHandler()
 
         when: "AccountNotFoundException is thrown"
-        def actual = target.handleAccountNotFoundException(new AccountNotFoundException(accountId))
+        final def actual = target.handleAccountNotFoundException(new AccountNotFoundException(accountId))
 
         then: "returned error will capture the Exception class and message from it"
         actual.getError() == new Error(

--- a/src/test/groovy/com/kinandcarta/transactionsapi/exception/AccountNotFoundExceptionSpec.groovy
+++ b/src/test/groovy/com/kinandcarta/transactionsapi/exception/AccountNotFoundExceptionSpec.groovy
@@ -6,16 +6,14 @@ import spock.lang.Specification
 import static utils.RandomGenerator.randomLong
 
 class AccountNotFoundExceptionSpec extends Specification {
-    def "should return expected message with accountId argument being passed in"() {
+    def "should return expected message with accountId"() {
         given: "an accountId"
         final def accountId = randomLong()
 
-        when:
-        "AccountNotFoundException is instantiated with accountId: ${accountId}"
+        when: "AccountNotFoundException is instantiated with accountId"
         final def target = new AccountNotFoundException(accountId);
 
-        then:
-        "it's message will have ${accountId} passed in, informing us card member was not found."
+        then: "it's message will have the accountId passed in, informing us that the card member was not found."
         target.getMessage() == "The card member account with an id of ${accountId} was not found.";
     }
 }

--- a/src/test/groovy/com/kinandcarta/transactionsapi/repository/AccountRepositorySpec.groovy
+++ b/src/test/groovy/com/kinandcarta/transactionsapi/repository/AccountRepositorySpec.groovy
@@ -10,10 +10,7 @@ import spock.lang.Specification
 class AccountRepositorySpec extends Specification {
 
     @Autowired
-    private TransactionRepository transactionRepository
-
-    @Autowired
-    private AccountRepository accountRepository
+    private AccountRepository target
 
     private final static long FIRST_ACCOUNT_ID = 789L
 
@@ -26,7 +23,7 @@ class AccountRepositorySpec extends Specification {
         final def accountId = FIRST_ACCOUNT_ID
 
         when: "findById is invoked with the account id"
-        final def actual = accountRepository.findById(accountId)
+        final def actual = target.findById(accountId)
 
         then: "returns only the account associated with the id"
         actual.get().getAccountId() == accountId
@@ -38,13 +35,13 @@ class AccountRepositorySpec extends Specification {
     }
 
     def saveFirstAccount() {
-        accountRepository.save(new AccountBuilder()
+        target.save(new AccountBuilder()
                 .withAccountId(789L)
                 .build())
     }
 
     def saveSecondAccount() {
-        accountRepository.save(new AccountBuilder()
+        target.save(new AccountBuilder()
                 .withAccountId(123L)
                 .build())
     }

--- a/src/test/groovy/com/kinandcarta/transactionsapi/repository/TransactionRepositorySpec.groovy
+++ b/src/test/groovy/com/kinandcarta/transactionsapi/repository/TransactionRepositorySpec.groovy
@@ -7,12 +7,14 @@ import datafixtures.TransactionBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import spock.lang.Specification
+import spock.lang.Subject
 
 import java.time.LocalDate
 
 import static java.util.Set.of
 
 @DataJpaTest
+@Subject(TransactionRepository)
 class TransactionRepositorySpec extends Specification {
 
     @Autowired

--- a/src/test/groovy/com/kinandcarta/transactionsapi/service/TransactionServiceSpec.groovy
+++ b/src/test/groovy/com/kinandcarta/transactionsapi/service/TransactionServiceSpec.groovy
@@ -13,12 +13,12 @@ import java.time.LocalDate
 class TransactionServiceSpec extends Specification {
     private TransactionRepository transactionRepositoryMock
     private AccountRepository accountRepositoryMock
-        private TransactionsService transactionsService
+    private TransactionsService target
 
     def setup() {
         transactionRepositoryMock = Mock(TransactionRepository)
         accountRepositoryMock = Mock(AccountRepository)
-        transactionsService = new TransactionsService(transactionRepositoryMock, accountRepositoryMock)
+        target = new TransactionsService(transactionRepositoryMock, accountRepositoryMock)
     }
 
     def "should retrieve transaction with a date equal to or greater than fromDate"() {
@@ -29,7 +29,7 @@ class TransactionServiceSpec extends Specification {
         final def transaction = new TransactionBuilder().build()
 
         when: "getTransactions is invoked"
-        final def actual = transactionsService.getTransactions(accountId, fromDate)
+        final def actual = target.getTransactions(accountId, fromDate)
 
         then: "returns expected transaction"
         verifyAll {
@@ -47,7 +47,7 @@ class TransactionServiceSpec extends Specification {
         final def transaction = new TransactionBuilder().build()
 
         when: "getTransactions is invoked"
-        final def actual = transactionsService.getTransactions(accountId, null)
+        final def actual = target.getTransactions(accountId, null)
 
         then: "returns expected transaction"
         verifyAll {
@@ -65,7 +65,7 @@ class TransactionServiceSpec extends Specification {
         final def transaction = new TransactionBuilder().build()
 
         when: "getTransaction is invoked but repository returns no results"
-        final def actual = transactionsService.getTransactions(accountId, null)
+        final def actual = target.getTransactions(accountId, null)
 
         then: "transactions will be empty"
         verifyAll {
@@ -87,7 +87,7 @@ class TransactionServiceSpec extends Specification {
         accountRepositoryMock.findById(accountId) >> Optional.empty()
 
         when: "getTransactions is invoked but no Account is found"
-        transactionsService.getTransactions(accountId, null)
+        target.getTransactions(accountId, null)
 
         then: "throws an AccountNotFoundException"
         final AccountNotFoundException actual = thrown(AccountNotFoundException)


### PR DESCRIPTION
Adding @Subject annotation to TransactionRepository spec
bc AccountRepository is used quite a bit in the setup.

